### PR TITLE
Fix index error bug

### DIFF
--- a/pkg/client/paged_query.go
+++ b/pkg/client/paged_query.go
@@ -68,12 +68,12 @@ func (query *PagedQuery) FetchNextPage() error {
 
 func (query *PagedQuery) NextEntity(result interface{}) (ok bool, err error) {
 	if query.index == query.maxIndex {
-		if !query.HasMorePages || query.Options.NoAutoFetchNextPage {
-			return false, nil
-		}
 		err := query.FetchNextPage()
 		if err != nil {
 			return false, err
+		}
+		if !query.HasMorePages || query.Options.NoAutoFetchNextPage {
+			return false, nil
 		}
 	}
 	query.index++


### PR DESCRIPTION
Fixing a bug where a command like:
`./homecli analytics --all-active | jq ".|keys"`

ends with:

```panic: runtime error: index out of range [0] with length 0

goroutine 1 [running]:
github.com/weka/gohomecli/pkg/client.(*PagedQuery).NextEntity(0xc00013a090, 0x139ef20, 0xc00013c6c0, 0xc0003d8000, 0x0, 0x0)
	/Users/ramivaknin/git/gohomecli/pkg/client/paged_query.go:83 +0x1a5
github.com/weka/gohomecli/pkg/client.(*PagedQuery).NextCluster(0xc00013a090, 0xc00013c5a0, 0x1, 0x0)
	/Users/ramivaknin/git/gohomecli/pkg/client/cluster.go:67 +0x5a
github.com/weka/gohomecli/internal/cli.glob..func5(0x16b5220, 0xc000057480, 0x0, 0x1)
	/Users/ramivaknin/git/gohomecli/internal/cli/analytics_cmd.go:50 +0x114
github.com/spf13/cobra.(*Command).execute(0x16b5220, 0xc000057470, 0x1, 0x1, 0x16b5220, 0xc000057470)
	/Users/ramivaknin/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:854 +0x2c2
github.com/spf13/cobra.(*Command).ExecuteC(0x16b4260, 0x10, 0xc00000e168, 0x200000000)
	/Users/ramivaknin/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:958 +0x375
github.com/spf13/cobra.(*Command).Execute(...)
	/Users/ramivaknin/go/pkg/mod/github.com/spf13/cobra@v1.1.1/command.go:895
github.com/weka/gohomecli/internal/cli.Execute()
	/Users/ramivaknin/git/gohomecli/internal/cli/root_cmd.go:40 +0x2d
main.main()
	/Users/ramivaknin/git/gohomecli/cmd/homecli/main.go:35 +0x95
exit status 2```