### PR TITLE
feat: additional user configuration for chart install

### DIFF
--- a/internal/cli/install/install.go
+++ b/internal/cli/install/install.go
@@ -13,10 +13,16 @@ import (
 
 var Cli hooks.Cli
 
+var installGroup = &cobra.Group{
+	ID:    "install",
+	Title: "Manage installations",
+}
+
 var installCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Manage installations",
-	Long:  "Manage wekahome installations",
+	Use:     "install",
+	Short:   "Manage installations",
+	Long:    "Manage wekahome installations",
+	GroupID: "install",
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		if !env.VerboseLogging {
 			utils.SetGlobalLoggingLevel(utils.InfoLevel)
@@ -26,6 +32,7 @@ var installCmd = &cobra.Command{
 
 func init() {
 	Cli.AddHook(func(appCmd *cobra.Command) {
+		appCmd.AddGroup(installGroup)
 		appCmd.AddCommand(installCmd)
 		k3s.Cli.InitCobra(installCmd)
 		chart.Cli.InitCobra(installCmd)

--- a/internal/install/chart/configuration.go
+++ b/internal/install/chart/configuration.go
@@ -1,6 +1,23 @@
 package chart
 
-// Configuration flat options for the chart
+// Configuration flat options for the chart, pointers are used to distinguish between empty and unset values
 type Configuration struct {
-	Host string `json:"host"`
+	Host    *string `json:"host"`    // ingress host
+	TLS     *bool   `json:"tls"`     // ingress tls enabled
+	TLSCert *string `json:"tlsCert"` // ingress tls cert
+	TLSKey  *string `json:"tlsKey"`  // ingress tls key
+
+	SMTPHost        *string `json:"smtpHost"`        // smtp server host
+	SMTPPort        *int    `json:"smtpPort"`        // smtp server port
+	SMTPUser        *string `json:"smtpUser"`        // smtp server user
+	SMTPPassword    *string `json:"smtpPassword"`    // smtp server password
+	SMTPInsecure    *bool   `json:"smtpInsecure"`    // smtp insecure connection
+	SMTPSender      *string `json:"smtpSender"`      // smtp sender name
+	SMTPSenderEmail *string `json:"smtpSenderEmail"` // smtp sender email
+
+	DiagnosticsRetentionDays *int `json:"diagnosticsRetentionDays"` // diagnostics retention days
+	EventsRetentionDays      *int `json:"eventsRetentionDays"`      // events retention days
+
+	Autoscaling     bool `json:"autoscaling"`        // enable services autoscaling
+	WekaNodesServed *int `json:"wekaNodesMonitored"` // number of weka nodes to monitor, controls load preset
 }

--- a/internal/install/chart/configuration.go
+++ b/internal/install/chart/configuration.go
@@ -18,6 +18,15 @@ type Configuration struct {
 	DiagnosticsRetentionDays *int `json:"diagnosticsRetentionDays"` // diagnostics retention days
 	EventsRetentionDays      *int `json:"eventsRetentionDays"`      // events retention days
 
+	ForwardingEnabled                   bool    `json:"forwardingEnabled"`                   // forwarding enabled
+	ForwardingUrl                       *string `json:"forwardingUrl"`                       // forwarding url override
+	ForwardingEnableEvents              *bool   `json:"forwardingEnableEvents"`              // forwarding enable events
+	ForwardingEnableUsageReports        *bool   `json:"forwardingEnableUsageReports"`        // forwarding enable usage reports
+	ForwardingEnableAnalytics           *bool   `json:"forwardingEnableAnalytics"`           // forwarding enable analytics
+	ForwardingEnableDiagnostics         *bool   `json:"forwardingEnableDiagnostics"`         // forwarding enable diagnostics
+	ForwardingEnableStats               *bool   `json:"forwardingEnableStats"`               // forwarding enable stats
+	ForwardingEnableClusterRegistration *bool   `json:"forwardingEnableClusterRegistration"` // forwarding enable cluster registration
+
 	Autoscaling     bool `json:"autoscaling"`        // enable services autoscaling
 	WekaNodesServed *int `json:"wekaNodesMonitored"` // number of weka nodes to monitor, controls load preset
 }

--- a/internal/install/chart/map.go
+++ b/internal/install/chart/map.go
@@ -9,6 +9,14 @@ var errConflictingKeys = fmt.Errorf("conflicting value overrides for key")
 
 type yamlMap = map[string]interface{}
 
+func writeMapEntryIfSet[T any](source yamlMap, key string, value *T) error {
+	if value == nil {
+		return nil
+	}
+
+	return writeMapEntry(source, key, value)
+}
+
 func writeMapEntry(source yamlMap, key string, value interface{}) error {
 	tokens := strings.Split(key, ".")
 	currentMap := source

--- a/internal/install/chart/map.go
+++ b/internal/install/chart/map.go
@@ -9,12 +9,12 @@ var errConflictingKeys = fmt.Errorf("conflicting value overrides for key")
 
 type yamlMap = map[string]interface{}
 
-func writeMapEntryIfSet[T any](source yamlMap, key string, value *T) error {
+func writeMapEntryIfPtrSet[T any](source yamlMap, key string, value *T) error {
 	if value == nil {
 		return nil
 	}
 
-	return writeMapEntry(source, key, value)
+	return writeMapEntry(source, key, *value)
 }
 
 func writeMapEntry(source yamlMap, key string, value interface{}) error {

--- a/internal/install/chart/v3.go
+++ b/internal/install/chart/v3.go
@@ -1,14 +1,144 @@
 package chart
 
+import (
+	"errors"
+	"fmt"
+)
+
 var valuesGeneratorV3 *yamlGenerator
 
 func configureIngress(configuration *Configuration) (yamlMap, error) {
 	cfg := make(yamlMap)
+	err := errors.Join(
+		writeMapEntryIfSet(cfg, "ingress.host", configuration.Host),
+		writeMapEntryIfSet(cfg, "workers.alertsDispatcher.emailLinkDomainName", configuration.Host),
+		writeMapEntryIfSet(cfg, "ingress.tls.enabled", configuration.TLS),
+		writeMapEntryIfSet(cfg, "ingress.tls.cert", configuration.TLSCert),
+		writeMapEntryIfSet(cfg, "ingress.tls.key", configuration.TLSKey),
+	)
 
-	if configuration.Host != "" {
-		if err := writeMapEntry(cfg, "ingress.host", configuration.Host); err != nil {
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func configureSMTP(configuration *Configuration) (yamlMap, error) {
+	cfg := make(yamlMap)
+	err := errors.Join(
+		writeMapEntryIfSet(cfg, "smtp.connection.host", configuration.SMTPHost),
+		writeMapEntryIfSet(cfg, "smtp.connection.port", configuration.SMTPPort),
+		writeMapEntryIfSet(cfg, "smtp.connection.username", configuration.SMTPUser),
+		writeMapEntryIfSet(cfg, "smtp.connection.password", configuration.SMTPPassword),
+		writeMapEntryIfSet(cfg, "smtp.connection.insecure", configuration.SMTPInsecure),
+		writeMapEntryIfSet(cfg, "smtp.senderEmailName", configuration.SMTPSender),
+		writeMapEntryIfSet(cfg, "smtp.senderEmail", configuration.SMTPSenderEmail),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+func configureRetention(configuration *Configuration) (yamlMap, error) {
+	cfg := make(yamlMap)
+	if configuration.DiagnosticsRetentionDays != nil {
+		retention := fmt.Sprintf("%dd", *configuration.DiagnosticsRetentionDays)
+		if err := writeMapEntry(cfg, "jobs.garbageCollector.diagnostics.maxAge", retention); err != nil {
 			return nil, err
 		}
+	}
+
+	if configuration.EventsRetentionDays != nil {
+		retention := fmt.Sprintf("%dd", *configuration.EventsRetentionDays)
+		if err := writeMapEntry(cfg, "jobs.garbageCollector.events.maxAge", retention); err != nil {
+			return nil, err
+		}
+	}
+
+	return cfg, nil
+}
+
+type replicasPreset struct {
+	Replicas int // default number of replicas
+	AMin     int // autoscaling min replicas
+	AMax     int // autoscaling max replicas
+}
+
+type appPreset struct {
+	NodesThreshold   int            // minimum number of weka nodes apply preset
+	MainApi          replicasPreset // preset for main-api
+	StatsApi         replicasPreset // preset for stats-api
+	StatsWorker      replicasPreset // preset for stats-worker
+	ForwardingWorker replicasPreset // preset for forwarding-worker
+}
+
+var resourcePresets []appPreset = []appPreset{
+	{
+		NodesThreshold:   1000,
+		MainApi:          replicasPreset{Replicas: 3, AMin: 3, AMax: 5},
+		StatsApi:         replicasPreset{Replicas: 3, AMin: 3, AMax: 5},
+		StatsWorker:      replicasPreset{Replicas: 3, AMin: 3, AMax: 10},
+		ForwardingWorker: replicasPreset{Replicas: 2, AMin: 2, AMax: 5},
+	},
+	{
+		NodesThreshold:   5000,
+		MainApi:          replicasPreset{Replicas: 5, AMin: 5, AMax: 8},
+		StatsApi:         replicasPreset{Replicas: 5, AMin: 5, AMax: 8},
+		StatsWorker:      replicasPreset{Replicas: 10, AMin: 10, AMax: 20},
+		ForwardingWorker: replicasPreset{Replicas: 3, AMin: 3, AMax: 8},
+	},
+}
+
+func configureResources(configuration *Configuration) (yamlMap, error) {
+	if configuration.WekaNodesServed == nil {
+		return yamlMap{}, nil
+	}
+
+	var preset *appPreset
+	for i := range resourcePresets {
+		if *configuration.WekaNodesServed >= resourcePresets[i].NodesThreshold {
+			preset = &resourcePresets[i]
+			break
+		}
+	}
+
+	// default preset is used if can not match
+	if preset == nil {
+		return yamlMap{}, nil
+	}
+
+	cfg := make(yamlMap)
+	var err error
+	if !configuration.Autoscaling {
+		err = errors.Join(
+			writeMapEntry(cfg, "api.main.replicas", preset.MainApi.Replicas),
+			writeMapEntry(cfg, "api.stats.replicas", preset.StatsApi.Replicas),
+			writeMapEntry(cfg, "workers.stats.replicas", preset.StatsWorker.Replicas),
+			writeMapEntry(cfg, "workers.forwarding.replicas", preset.ForwardingWorker.Replicas),
+		)
+	} else {
+		err = errors.Join(
+			writeMapEntry(cfg, "api.main.autoscaling.enabled", true),
+			writeMapEntry(cfg, "api.main.autoscaling.minReplicas", preset.MainApi.AMin),
+			writeMapEntry(cfg, "api.main.autoscaling.maxReplicas", preset.MainApi.AMax),
+			writeMapEntry(cfg, "api.stats.autoscaling.enabled", true),
+			writeMapEntry(cfg, "api.stats.autoscaling.minReplicas", preset.StatsApi.AMin),
+			writeMapEntry(cfg, "api.stats.autoscaling.maxReplicas", preset.StatsApi.AMax),
+			writeMapEntry(cfg, "workers.stats.autoscaling.enabled", true),
+			writeMapEntry(cfg, "workers.stats.autoscaling.minReplicas", preset.StatsWorker.AMin),
+			writeMapEntry(cfg, "workers.stats.autoscaling.maxReplicas", preset.StatsWorker.AMax),
+			writeMapEntry(cfg, "workers.forwarding.autoscaling.enabled", true),
+			writeMapEntry(cfg, "workers.forwarding.autoscaling.minReplicas", preset.ForwardingWorker.AMin),
+			writeMapEntry(cfg, "workers.forwarding.autoscaling.maxReplicas", preset.ForwardingWorker.AMax),
+		)
+	}
+
+	if err != nil {
+		return nil, err
 	}
 
 	return cfg, nil
@@ -20,6 +150,9 @@ func init() {
 	}
 
 	valuesGeneratorV3.AddVisitor("ingress", configureIngress)
+	valuesGeneratorV3.AddVisitor("smtp", configureSMTP)
+	valuesGeneratorV3.AddVisitor("retention", configureRetention)
+	valuesGeneratorV3.AddVisitor("resources", configureResources)
 }
 
 func generateValuesV3(configuration *Configuration) (map[string]interface{}, error) {

--- a/internal/install/chart/v3.go
+++ b/internal/install/chart/v3.go
@@ -10,11 +10,11 @@ var valuesGeneratorV3 *yamlGenerator
 func configureIngress(configuration *Configuration) (yamlMap, error) {
 	cfg := make(yamlMap)
 	err := errors.Join(
-		writeMapEntryIfSet(cfg, "ingress.host", configuration.Host),
-		writeMapEntryIfSet(cfg, "workers.alertsDispatcher.emailLinkDomainName", configuration.Host),
-		writeMapEntryIfSet(cfg, "ingress.tls.enabled", configuration.TLS),
-		writeMapEntryIfSet(cfg, "ingress.tls.cert", configuration.TLSCert),
-		writeMapEntryIfSet(cfg, "ingress.tls.key", configuration.TLSKey),
+		writeMapEntryIfPtrSet(cfg, "ingress.host", configuration.Host),
+		writeMapEntryIfPtrSet(cfg, "workers.alertsDispatcher.emailLinkDomainName", configuration.Host),
+		writeMapEntryIfPtrSet(cfg, "ingress.tls.enabled", configuration.TLS),
+		writeMapEntryIfPtrSet(cfg, "ingress.tls.cert", configuration.TLSCert),
+		writeMapEntryIfPtrSet(cfg, "ingress.tls.key", configuration.TLSKey),
 	)
 
 	if err != nil {
@@ -27,13 +27,13 @@ func configureIngress(configuration *Configuration) (yamlMap, error) {
 func configureSMTP(configuration *Configuration) (yamlMap, error) {
 	cfg := make(yamlMap)
 	err := errors.Join(
-		writeMapEntryIfSet(cfg, "smtp.connection.host", configuration.SMTPHost),
-		writeMapEntryIfSet(cfg, "smtp.connection.port", configuration.SMTPPort),
-		writeMapEntryIfSet(cfg, "smtp.connection.username", configuration.SMTPUser),
-		writeMapEntryIfSet(cfg, "smtp.connection.password", configuration.SMTPPassword),
-		writeMapEntryIfSet(cfg, "smtp.connection.insecure", configuration.SMTPInsecure),
-		writeMapEntryIfSet(cfg, "smtp.senderEmailName", configuration.SMTPSender),
-		writeMapEntryIfSet(cfg, "smtp.senderEmail", configuration.SMTPSenderEmail),
+		writeMapEntryIfPtrSet(cfg, "smtp.connection.host", configuration.SMTPHost),
+		writeMapEntryIfPtrSet(cfg, "smtp.connection.port", configuration.SMTPPort),
+		writeMapEntryIfPtrSet(cfg, "smtp.connection.username", configuration.SMTPUser),
+		writeMapEntryIfPtrSet(cfg, "smtp.connection.password", configuration.SMTPPassword),
+		writeMapEntryIfPtrSet(cfg, "smtp.connection.insecure", configuration.SMTPInsecure),
+		writeMapEntryIfPtrSet(cfg, "smtp.senderEmailName", configuration.SMTPSender),
+		writeMapEntryIfPtrSet(cfg, "smtp.senderEmail", configuration.SMTPSenderEmail),
 	)
 
 	if err != nil {
@@ -144,6 +144,30 @@ func configureResources(configuration *Configuration) (yamlMap, error) {
 	return cfg, nil
 }
 
+func configureForwarding(configuration *Configuration) (yamlMap, error) {
+	if !configuration.ForwardingEnabled {
+		return yamlMap{}, nil
+	}
+
+	cfg := make(yamlMap)
+	err := errors.Join(
+		writeMapEntry(cfg, "forwarding.enabled", true),
+		writeMapEntryIfPtrSet(cfg, "forwarding.url", configuration.ForwardingUrl),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableEvents", configuration.ForwardingEnableEvents),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableUsageReports", configuration.ForwardingEnableUsageReports),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableAnalytics", configuration.ForwardingEnableAnalytics),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableDiagnostics", configuration.ForwardingEnableDiagnostics),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableStats", configuration.ForwardingEnableStats),
+		writeMapEntryIfPtrSet(cfg, "forwarding.categories.enableClusterRegistration", configuration.ForwardingEnableClusterRegistration),
+	)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
 func init() {
 	valuesGeneratorV3 = &yamlGenerator{
 		visitors: map[string]configVisitor{},
@@ -153,6 +177,7 @@ func init() {
 	valuesGeneratorV3.AddVisitor("smtp", configureSMTP)
 	valuesGeneratorV3.AddVisitor("retention", configureRetention)
 	valuesGeneratorV3.AddVisitor("resources", configureResources)
+	valuesGeneratorV3.AddVisitor("forwarding", configureForwarding)
 }
 
 func generateValuesV3(configuration *Configuration) (map[string]interface{}, error) {


### PR DESCRIPTION
Following usecases were used for generated configuration

**Ingress Configuration**: Host, TLS, TLSCert, TLSKey
**SMTP Configuration**: SMTPHost, SMTPPort, SMTPUser, SMTPPassword, SMTPInsecure, SMTPSender, SMTPSenderEmail
**Retention Configuration**: DiagnosticsRetentionDays, EventsRetentionDays
**Forwarding Configuration**: ForwardingEnabled, ForwardingUrl, ForwardingEnableEvents, ForwardingEnableUsageReports, ForwardingEnableAnalytics, ForwardingEnableDiagnostics, ForwardingEnableStats, ForwardingEnableClusterRegistration
**Autoscaling Configuration**: Autoscaling, WekaNodesServed