### PR TITLE
feat: add storage configuration for nats (WH-1920)

### DIFF
--- a/internal/local/config/v1/v1.go
+++ b/internal/local/config/v1/v1.go
@@ -35,6 +35,10 @@ type ProxyConfig struct {
 	URL string `json:"url,omitempty"`
 }
 
+type StorageConfig struct {
+	Nats int `json:"nats,omitempty"`
+}
+
 // Configuration flat options for the chart, pointers are used to distinguish between empty and unset values
 type Configuration struct {
 	Host          string           `json:"host,omitempty"` // ingress host
@@ -44,6 +48,8 @@ type Configuration struct {
 	SMTP          SMTPConfig       `json:"smtp,omitempty"`
 	RetentionDays RetentionConfig  `json:"retentionDays,omitempty"`
 	Forwarding    ForwardingConfig `json:"forwarding,omitempty"`
+
+	Storage StorageConfig `json:"storage,omitempty"`
 
 	Autoscaling     *bool `json:"autoscaling,omitempty"`        // enable services autoscaling
 	WekaNodesServed int   `json:"wekaNodesMonitored,omitempty"` // number of weka nodes to monitor, controls load preset


### PR DESCRIPTION
This PR allows to set storage for nats streams, with configuration for each stream limit.

As PVC configuration is by default 10G for NATS, but in LWH we're having local-path-provisioner - PVC settings is not required, NATS will be able to use all host storage.