### PR TITLE
feat: add WH pod status and WH address checks to cli (WH-2773)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
-	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -177,4 +176,5 @@ require (
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.17.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
+	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	k8s.io/api v0.31.1
 	k8s.io/apimachinery v0.31.1
 	k8s.io/client-go v0.31.1
+	sigs.k8s.io/yaml v1.4.0
 )
 
 require (
@@ -176,5 +177,4 @@ require (
 	sigs.k8s.io/kustomize/api v0.17.2 // indirect
 	sigs.k8s.io/kustomize/kyaml v0.17.1 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.4.1 // indirect
-	sigs.k8s.io/yaml v1.4.0 // indirect
 )

--- a/internal/cli/local/local.go
+++ b/internal/cli/local/local.go
@@ -41,6 +41,7 @@ func init() {
 		setup.Cli.InitCobra(localCmd)
 		upgrade.Cli.InitCobra(localCmd)
 		cleanup.Cli.InitCobra(localCmd)
-		status.Cli.InitCobra(localCmd)
+		statusCli := status.CliHook()
+		statusCli.InitCobra(localCmd)
 	})
 }

--- a/internal/cli/local/local.go
+++ b/internal/cli/local/local.go
@@ -7,6 +7,7 @@ import (
 	"github.com/weka/gohomecli/internal/cli/local/cleanup"
 	"github.com/weka/gohomecli/internal/cli/local/debug"
 	"github.com/weka/gohomecli/internal/cli/local/setup"
+	"github.com/weka/gohomecli/internal/cli/local/status"
 	"github.com/weka/gohomecli/internal/cli/local/upgrade"
 	"github.com/weka/gohomecli/internal/env"
 	"github.com/weka/gohomecli/internal/utils"
@@ -40,5 +41,6 @@ func init() {
 		setup.Cli.InitCobra(localCmd)
 		upgrade.Cli.InitCobra(localCmd)
 		cleanup.Cli.InitCobra(localCmd)
+		status.Cli.InitCobra(localCmd)
 	})
 }

--- a/internal/cli/local/status/status.go
+++ b/internal/cli/local/status/status.go
@@ -81,7 +81,7 @@ var wekahomeCmd = &cobra.Command{
 		}
 
 		url := fmt.Sprintf("http://%s", address)
-		statusCode, err := utils.GetUrlStatusCode(url)
+		statusCode, err := utils.GetURLStatusCode(url)
 		if err != nil {
 			utils.UserError(err.Error())
 		}

--- a/internal/cli/local/status/status.go
+++ b/internal/cli/local/status/status.go
@@ -1,0 +1,63 @@
+package status
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/yaml"
+
+	"github.com/weka/gohomecli/internal/cli/app/hooks"
+	"github.com/weka/gohomecli/internal/local/chart"
+	"github.com/weka/gohomecli/internal/utils"
+)
+
+var Cli hooks.Cli
+
+var statusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Get the status of pods",
+	Long:  "Get the status of non-running or completed pods in home-weka-io namespace",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		detailed, _ := cmd.Flags().GetBool("detailed")
+		outputFormat, _ := cmd.Flags().GetString("output")
+
+		pods, err := chart.GetNonRunningOrCompletedPods()
+		if err != nil {
+			utils.UserError(err.Error())
+		}
+		if len(pods) == 0 {
+			utils.UserOutput("All pods are running.")
+			return nil
+		}
+		var output []byte
+		if outputFormat == "json" {
+			output, err = json.Marshal(pods)
+		} else {
+			output, err = yaml.Marshal(pods)
+		}
+		if err != nil {
+			utils.UserError(err.Error())
+		}
+
+		if detailed {
+			utils.UserOutput(string(output))
+		} else {
+			utils.UserOutput("Non-running or completed pods:")
+			for _, pod := range pods {
+				utils.UserOutput(fmt.Sprintf("- %s", pod.Name))
+			}
+		}
+		utils.UserError("There are non-running or completed pods.")
+		return nil
+	},
+}
+
+func init() {
+	statusCmd.Flags().BoolP("detailed", "d", false, "Show detailed information")
+	statusCmd.Flags().StringP("output", "o", "human", "Output format (json or human)")
+
+	Cli.AddHook(func(appCmd *cobra.Command) {
+		appCmd.AddCommand(statusCmd)
+	})
+}

--- a/internal/cli/local/status/status.go
+++ b/internal/cli/local/status/status.go
@@ -16,32 +16,45 @@ var Cli hooks.Cli
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
+	Short: "Get the status of Weka Home components",
+	Long:  "Get the status of Weka Home components, including pods and the entire Weka Home instance",
+}
+
+var podsCmd = &cobra.Command{
+	Use:   "pods",
 	Short: "Get the status of pods",
-	Long:  "Get the status of non-running or completed pods in home-weka-io namespace",
+	Long:  fmt.Sprintf("Get the status of non-running or completed pods in the %s namespace", chart.ReleaseNamespace),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		detailed, _ := cmd.Flags().GetBool("detailed")
 		outputFormat, _ := cmd.Flags().GetString("output")
+
+		if !detailed && cmd.Flags().Changed("output") {
+			utils.UserError("The --output flag can only be used with the --detailed flag.")
+		}
 
 		pods, err := chart.GetNonRunningOrCompletedPods()
 		if err != nil {
 			utils.UserError(err.Error())
 		}
 		if len(pods) == 0 {
-			utils.UserOutput("All pods are running.")
+			utils.UserNote("All pods are running.")
 			return nil
 		}
-		var output []byte
-		if outputFormat == "json" {
-			output, err = json.Marshal(pods)
-		} else {
-			output, err = yaml.Marshal(pods)
-		}
-		if err != nil {
-			utils.UserError(err.Error())
-		}
-
 		if detailed {
-			utils.UserOutput(string(output))
+			var output []byte
+			if outputFormat == "json" {
+				output, err = json.Marshal(pods)
+				if err != nil {
+					utils.UserError(err.Error())
+				}
+				utils.UserOutputJSON(output)
+			} else {
+				output, err = yaml.Marshal(pods)
+				if err != nil {
+					utils.UserError(err.Error())
+				}
+				utils.UserOutput(string(output))
+			}
 		} else {
 			utils.UserOutput("Non-running or completed pods:")
 			for _, pod := range pods {
@@ -53,9 +66,40 @@ var statusCmd = &cobra.Command{
 	},
 }
 
+var wekahomeCmd = &cobra.Command{
+	Use:   "wekahome",
+	Short: "Check the status of the running local Weka Home instance",
+	Long:  "Check the status of the running local Weka Home instance by querying the ingress address",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		address, err := chart.GetIngressAddress()
+		if err != nil {
+			utils.UserError(err.Error())
+		}
+		if address == "" {
+			errStr := fmt.Sprintf("No ingress found in the %s namespace", chart.ReleaseNamespace)
+			utils.UserError(errStr)
+		}
+
+		url := fmt.Sprintf("http://%s", address)
+		statusCode, err := utils.GetUrlStatusCode(url)
+		if err != nil {
+			utils.UserError(err.Error())
+		}
+		if statusCode != 200 {
+			errStr := fmt.Sprintf("Something wrong with WekaHome. Status code: %d", statusCode)
+			utils.UserError(errStr)
+		}
+		utils.UserNote("WekaHome is running.")
+		return nil
+	},
+}
+
 func init() {
-	statusCmd.Flags().BoolP("detailed", "d", false, "Show detailed information")
-	statusCmd.Flags().StringP("output", "o", "human", "Output format (json or human)")
+	podsCmd.PersistentFlags().BoolP("detailed", "d", false, "Show detailed information")
+	podsCmd.PersistentFlags().StringP("output", "o", "human", "Output format (json or human)")
+
+	statusCmd.AddCommand(podsCmd)
+	statusCmd.AddCommand(wekahomeCmd)
 
 	Cli.AddHook(func(appCmd *cobra.Command) {
 		appCmd.AddCommand(statusCmd)

--- a/internal/cli/local/status/status.go
+++ b/internal/cli/local/status/status.go
@@ -5,103 +5,133 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
-	"sigs.k8s.io/yaml"
 
 	"github.com/weka/gohomecli/internal/cli/app/hooks"
 	"github.com/weka/gohomecli/internal/local/chart"
 	"github.com/weka/gohomecli/internal/utils"
 )
 
-var Cli hooks.Cli
+func CliHook() hooks.Cli {
+	var cli hooks.Cli
 
-var statusCmd = &cobra.Command{
-	Use:   "status",
-	Short: "Get the status of Weka Home components",
-	Long:  "Get the status of Weka Home components, including pods and the entire Weka Home instance",
-}
+	statusCmd := &cobra.Command{
+		Use:   "status",
+		Short: "Get the status of Weka Home components",
+		Long:  "Get the status of Weka Home components, including pods and the entire Weka Home instance",
+	}
 
-var podsCmd = &cobra.Command{
-	Use:   "pods",
-	Short: "Check the status of pods",
-	Long:  fmt.Sprintf("Check the status of pods and get non-running ones in the %s namespace", chart.ReleaseNamespace),
-	RunE: func(cmd *cobra.Command, args []string) error {
-		detailed, _ := cmd.Flags().GetBool("detailed")
-		outputFormat, _ := cmd.Flags().GetString("output")
-
-		if !detailed && cmd.Flags().Changed("output") {
-			utils.UserError("The --output flag can only be used with the --detailed flag.")
-		}
-
-		pods, err := chart.GetNonRuninngPods()
-		if err != nil {
-			utils.UserError(err.Error())
-		}
-		if len(pods) == 0 {
-			utils.UserNote("All pods are running.")
-			return nil
-		}
-		if detailed {
-			var output []byte
-			if outputFormat == "json" {
-				output, err = json.Marshal(pods)
-				if err != nil {
-					utils.UserError(err.Error())
-				}
-				utils.UserOutputJSON(output)
-			} else {
-				output, err = yaml.Marshal(pods)
-				if err != nil {
-					utils.UserError(err.Error())
-				}
-				utils.UserOutput(string(output))
-			}
-		} else {
-			utils.UserOutput("Non-running pods:")
-			for _, pod := range pods {
-				utils.UserOutput(fmt.Sprintf("- Pod name: \"%s\", Pod Status: \"%s\"", pod.Name, pod.Status.Phase))
-			}
-		}
-		utils.UserError("There are non-running pods.")
-		return nil
-	},
-}
-
-var wekahomeCmd = &cobra.Command{
-	Use:   "wekahome",
-	Short: "Check the status of the running local Weka Home instance",
-	Long:  "Check the status of the running local Weka Home instance by querying the ingress address",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		address, err := chart.GetIngressAddress()
-		if err != nil {
-			utils.UserError(err.Error())
-		}
-		if address == "" {
-			errStr := fmt.Sprintf("No ingress found in the %s namespace", chart.ReleaseNamespace)
-			utils.UserError(errStr)
-		}
-
-		url := fmt.Sprintf("http://%s", address)
-		statusCode, err := utils.GetURLStatusCode(url)
-		if err != nil {
-			utils.UserError(err.Error())
-		}
-		if statusCode != 200 {
-			errStr := fmt.Sprintf("Something wrong with WekaHome. Address: %s, HTTP Status code: %d", url, statusCode)
-			utils.UserError(errStr)
-		}
-		utils.UserNote("WekaHome is running.")
-		return nil
-	},
-}
-
-func init() {
+	podsCmd := &cobra.Command{
+		Use:   "pods",
+		Short: "Check the status of pods",
+		Long:  fmt.Sprintf("Check the status of pods and get non-running ones in the %s namespace", chart.ReleaseNamespace),
+		RunE:  podsRun,
+	}
 	podsCmd.PersistentFlags().BoolP("detailed", "d", false, "Show detailed information")
 	podsCmd.PersistentFlags().StringP("output", "o", "human", "Output format (json or human)")
 
 	statusCmd.AddCommand(podsCmd)
+
+	wekahomeCmd := &cobra.Command{
+		Use:   "wekahome",
+		Short: "Check the status of the running local Weka Home instance",
+		Long:  "Check the status of the running local Weka Home instance by querying the ingress address",
+		RunE:  wekaHomeRun,
+	}
+
 	statusCmd.AddCommand(wekahomeCmd)
 
-	Cli.AddHook(func(appCmd *cobra.Command) {
+	cli.AddHook(func(appCmd *cobra.Command) {
 		appCmd.AddCommand(statusCmd)
 	})
+	return cli
+}
+
+func podsRun(cmd *cobra.Command, args []string) error {
+	detailed, _ := cmd.Flags().GetBool("detailed")
+	outputFormat, _ := cmd.Flags().GetString("output")
+
+	pods, err := chart.GetNonRuninngPods(cmd.Context())
+	if err != nil {
+		utils.UserError(err.Error())
+	}
+
+	isHealthy := len(pods) == 0
+
+	if outputFormat == "json" {
+		return outputPodsAsJSON(pods, isHealthy, detailed)
+	}
+	return outputPodsAsTable(pods, isHealthy, detailed)
+}
+
+func outputPodsAsJSON(pods []chart.PodInfo, isHealthy bool, detailed bool) error {
+
+	type StatusResponse struct {
+		Healthy    bool            `json:"healthy"`
+		FaultyPods []chart.PodInfo `json:"faultyPods,omitempty"`
+	}
+
+	response := StatusResponse{
+		Healthy: isHealthy,
+	}
+
+	if detailed && !isHealthy {
+		response.FaultyPods = pods
+	}
+
+	output, err := json.Marshal(response)
+	if err != nil {
+		return err
+	}
+
+	utils.UserOutputJSON(output)
+
+	return nil
+}
+
+func outputPodsAsTable(pods []chart.PodInfo, isHealthy bool, detailed bool) error {
+	if isHealthy {
+		utils.UserNote("All pods are running.")
+		return nil
+	}
+	if detailed {
+		utils.UserOutput("Faulty pods:")
+		headers := []string{"Pod Name", "Status", "Reason"}
+		index := 0
+		utils.RenderTableRows(headers, func() []string {
+			if index < len(pods) {
+				pod := pods[index]
+				index++
+				return []string{
+					pod.Name,
+					pod.Status,
+					pod.Reason,
+				}
+			}
+			return nil
+		})
+	}
+	return nil
+}
+
+func wekaHomeRun(cmd *cobra.Command, args []string) error {
+	address, err := chart.GetIngressAddress()
+	if err != nil {
+		utils.UserError(err.Error())
+	}
+	if address == "" {
+		errStr := fmt.Sprintf("No ingress found in the %s namespace", chart.ReleaseNamespace)
+		utils.UserError(errStr)
+	}
+
+	url := fmt.Sprintf("http://%s", address)
+	statusCode, err := utils.GetURLStatusCode(url)
+	if err != nil {
+		utils.UserError(err.Error())
+	}
+	if statusCode != 200 {
+		errStr := fmt.Sprintf("Something wrong with WekaHome. Address: %s, HTTP Status code: %d", url, statusCode)
+		utils.UserError(errStr)
+	}
+	utils.UserNote("WekaHome is running.")
+	return nil
 }

--- a/internal/cli/local/status/status.go
+++ b/internal/cli/local/status/status.go
@@ -22,8 +22,8 @@ var statusCmd = &cobra.Command{
 
 var podsCmd = &cobra.Command{
 	Use:   "pods",
-	Short: "Get the status of pods",
-	Long:  fmt.Sprintf("Get the status of non-running or completed pods in the %s namespace", chart.ReleaseNamespace),
+	Short: "Check the status of pods",
+	Long:  fmt.Sprintf("Check the status of pods and get non-running ones in the %s namespace", chart.ReleaseNamespace),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		detailed, _ := cmd.Flags().GetBool("detailed")
 		outputFormat, _ := cmd.Flags().GetString("output")
@@ -32,7 +32,7 @@ var podsCmd = &cobra.Command{
 			utils.UserError("The --output flag can only be used with the --detailed flag.")
 		}
 
-		pods, err := chart.GetNonRunningOrCompletedPods()
+		pods, err := chart.GetNonRuninngPods()
 		if err != nil {
 			utils.UserError(err.Error())
 		}
@@ -56,12 +56,12 @@ var podsCmd = &cobra.Command{
 				utils.UserOutput(string(output))
 			}
 		} else {
-			utils.UserOutput("Non-running or completed pods:")
+			utils.UserOutput("Non-running pods:")
 			for _, pod := range pods {
-				utils.UserOutput(fmt.Sprintf("- %s", pod.Name))
+				utils.UserOutput(fmt.Sprintf("- Pod name: \"%s\", Pod Status: \"%s\"", pod.Name, pod.Status.Phase))
 			}
 		}
-		utils.UserError("There are non-running or completed pods.")
+		utils.UserError("There are non-running pods.")
 		return nil
 	},
 }
@@ -86,7 +86,7 @@ var wekahomeCmd = &cobra.Command{
 			utils.UserError(err.Error())
 		}
 		if statusCode != 200 {
-			errStr := fmt.Sprintf("Something wrong with WekaHome. Status code: %d", statusCode)
+			errStr := fmt.Sprintf("Something wrong with WekaHome. Address: %s, HTTP Status code: %d", url, statusCode)
 			utils.UserError(errStr)
 		}
 		utils.UserNote("WekaHome is running.")

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -151,3 +151,31 @@ func GetNonRunningOrCompletedPods() ([]corev1.Pod, error) {
 
 	return nonRunningOrCompletedPods, nil
 }
+
+func GetIngressAddress() (string, error) {
+	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
+	if err != nil {
+		return "", err
+	}
+
+	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return "", err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", err
+	}
+
+	ingresses, err := clientset.NetworkingV1().Ingresses(ReleaseNamespace).List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		return "", err
+	}
+
+	if len(ingresses.Items) == 0 {
+		return "", fmt.Errorf("no ingress found in namespace %s", ReleaseNamespace)
+	}
+
+	return ingresses.Items[0].Spec.Rules[0].Host, nil
+}

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -7,11 +7,12 @@ import (
 	"path/filepath"
 
 	helmclient "github.com/mittwald/go-helm-client"
-	"github.com/weka/gohomecli/internal/utils"
 	corev1 "k8s.io/api/core/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/weka/gohomecli/internal/utils"
 )
 
 const KubeConfigPath = "/etc/rancher/k3s/k3s.yaml"
@@ -110,4 +111,43 @@ func watchWarningEvents(ctx context.Context, namespace string, kubeconfig []byte
 	}()
 
 	return ch, watcher.Stop, nil
+}
+
+// returns a list of non-running or completed pods in the specified namespace
+func GetNonRunningOrCompletedPods() ([]corev1.Pod, error) {
+	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+
+	config, err := clientcmd.RESTConfigFromKubeConfig(kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	pods, err := clientset.CoreV1().Pods(ReleaseNamespace).List(context.TODO(), v1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	var nonRunningOrCompletedPods []corev1.Pod
+	for _, pod := range pods.Items {
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			state := containerStatus.State
+			if state.Waiting != nil || state.Terminated != nil {
+				if state.Terminated != nil && state.Terminated.Reason == "Completed" {
+					continue
+				}
+				nonRunningOrCompletedPods = append(nonRunningOrCompletedPods, pod)
+				break
+			}
+		}
+	}
+
+	return nonRunningOrCompletedPods, nil
 }

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -113,7 +113,7 @@ func watchWarningEvents(ctx context.Context, namespace string, kubeconfig []byte
 	return ch, watcher.Stop, nil
 }
 
-// GetNonRuninngPods returns a list of non-running or completed pods in the specified namespace
+// GetNonRuninngPods returns a list of non-running pods in the ReleaseNamespace namespace
 func GetNonRuninngPods() ([]corev1.Pod, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {
@@ -152,7 +152,7 @@ func GetNonRuninngPods() ([]corev1.Pod, error) {
 	return nonRunningOrCompletedPods, nil
 }
 
-// GetIngressAddress returns the address of the ingress in the specified namespace
+// GetIngressAddress returns the address of the ingress in ReleaseNamespace namespace
 func GetIngressAddress() (string, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -113,8 +113,8 @@ func watchWarningEvents(ctx context.Context, namespace string, kubeconfig []byte
 	return ch, watcher.Stop, nil
 }
 
-// GetNonRunningOrCompletedPods returns a list of non-running or completed pods in the specified namespace
-func GetNonRunningOrCompletedPods() ([]corev1.Pod, error) {
+// GetNonRuninngPods returns a list of non-running or completed pods in the specified namespace
+func GetNonRuninngPods() ([]corev1.Pod, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -178,5 +178,17 @@ func GetIngressAddress() (string, error) {
 		return "", fmt.Errorf("no ingress found in namespace %s", ReleaseNamespace)
 	}
 
-	return ingresses.Items[0].Spec.Rules[0].Host, nil
+	ingress := ingresses.Items[0]
+	for _, rule := range ingress.Spec.Rules {
+		if rule.Host != "" && rule.Host != "*" {
+			return rule.Host, nil
+		}
+	}
+
+	// If no specific host is found, return the address
+	if len(ingress.Status.LoadBalancer.Ingress) > 0 {
+		return ingress.Status.LoadBalancer.Ingress[0].IP, nil
+	}
+
+	return "", fmt.Errorf("no valid host or address found for ingress %s in namespace %s", ingress.Name, ReleaseNamespace)
 }

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -113,8 +113,20 @@ func watchWarningEvents(ctx context.Context, namespace string, kubeconfig []byte
 	return ch, watcher.Stop, nil
 }
 
+func isNonRunningOrIncomplete(containerStatus corev1.ContainerStatus) bool {
+	containerState := containerStatus.State
+	return containerState.Waiting != nil || (containerState.Terminated != nil && containerState.Terminated.Reason != "Completed")
+}
+
+// PodInfo represents short information about a pod
+type PodInfo struct {
+	Name   string `json:"name"`
+	Status string `json:"status"`
+	Reason string `json:"reason"`
+}
+
 // GetNonRuninngPods returns a list of non-running pods in the ReleaseNamespace namespace
-func GetNonRuninngPods() ([]corev1.Pod, error) {
+func GetNonRuninngPods(ctx context.Context) ([]PodInfo, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {
 		return nil, err
@@ -130,26 +142,50 @@ func GetNonRuninngPods() ([]corev1.Pod, error) {
 		return nil, err
 	}
 
-	pods, err := clientset.CoreV1().Pods(ReleaseNamespace).List(context.TODO(), v1.ListOptions{})
+	pods, err := clientset.CoreV1().Pods(ReleaseNamespace).List(ctx, v1.ListOptions{})
 	if err != nil {
 		return nil, err
 	}
 
-	var nonRunningOrCompletedPods []corev1.Pod
+	var nonRunningOrCompletedPods []PodInfo
 	for _, pod := range pods.Items {
 		for _, containerStatus := range pod.Status.ContainerStatuses {
-			state := containerStatus.State
-			if state.Waiting != nil || state.Terminated != nil {
-				if state.Terminated != nil && state.Terminated.Reason == "Completed" {
-					continue
-				}
-				nonRunningOrCompletedPods = append(nonRunningOrCompletedPods, pod)
+			if isNonRunningOrIncomplete(containerStatus) {
+				reason := getContainerStatusReason(containerStatus, pod.Status.Reason)
+				nonRunningOrCompletedPods = append(nonRunningOrCompletedPods, PodInfo{
+					Name:   pod.Name,
+					Status: string(pod.Status.Phase),
+					Reason: reason,
+				})
 				break
 			}
 		}
 	}
 
 	return nonRunningOrCompletedPods, nil
+}
+
+// getContainerStatusReason extracts the most specific status reason from a container
+func getContainerStatusReason(containerStatus corev1.ContainerStatus, podReason string) string {
+	// Try to get the waiting reason first (most common for problems like ImagePullBackOff)
+	if containerStatus.State.Waiting != nil && containerStatus.State.Waiting.Reason != "" {
+		return containerStatus.State.Waiting.Reason
+	}
+
+	// If not waiting, try terminated state (but not if it's completed normally)
+	if containerStatus.State.Terminated != nil &&
+		containerStatus.State.Terminated.Reason != "Completed" &&
+		containerStatus.State.Terminated.Reason != "" {
+		return containerStatus.State.Terminated.Reason
+	}
+
+	// If container state doesn't have a reason, fall back to pod reason
+	if podReason != "" {
+		return podReason
+	}
+
+	// Default for when container is not running but no specific reason is found
+	return "Unknown"
 }
 
 // GetIngressAddress returns the address of the ingress in ReleaseNamespace namespace

--- a/internal/local/chart/kube.go
+++ b/internal/local/chart/kube.go
@@ -113,7 +113,7 @@ func watchWarningEvents(ctx context.Context, namespace string, kubeconfig []byte
 	return ch, watcher.Stop, nil
 }
 
-// returns a list of non-running or completed pods in the specified namespace
+// GetNonRunningOrCompletedPods returns a list of non-running or completed pods in the specified namespace
 func GetNonRunningOrCompletedPods() ([]corev1.Pod, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {
@@ -152,6 +152,7 @@ func GetNonRunningOrCompletedPods() ([]corev1.Pod, error) {
 	return nonRunningOrCompletedPods, nil
 }
 
+// GetIngressAddress returns the address of the ingress in the specified namespace
 func GetIngressAddress() (string, error) {
 	kubeconfig, err := ReadKubeConfig(KubeConfigPath)
 	if err != nil {

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -197,7 +197,8 @@ func URLSafe(u *url.URL) *url.URL {
 	return &urlSafe
 }
 
-func GetUrlStatusCode(url string) (int, error) {
+// GetURLStatusCode returns the status code of a given URL
+func GetURLStatusCode(url string) (int, error) {
 	resp, err := http.Get(url)
 	if err != nil {
 		return 0, err

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -194,4 +195,12 @@ func URLSafe(u *url.URL) *url.URL {
 	urlSafe := *u
 	urlSafe.User = url.UserPassword(u.User.Username(), "[HIDDEN]")
 	return &urlSafe
+}
+
+func GetUrlStatusCode(url string) (int, error) {
+	resp, err := http.Get(url)
+	if err != nil {
+		return 0, err
+	}
+	return resp.StatusCode, nil
 }


### PR DESCRIPTION
CLI commands added:

1. Check the status of pods in `home-weka-io` namespace, if found non running pods will show them(depending on given flag):
```
homecli local status pods [flags]

Flags:
  -d, --detailed        Show detailed information
  -o, --output string   Output format (json or human) (default "human")
```

2. Check ingress address in `home-weka-io` namespace is returning 200:

```
homecli local status wekahome
```