### PR TITLE
chore: disable operator for k8s stack

### DIFF
--- a/internal/local/chart/v3.go
+++ b/internal/local/chart/v3.go
@@ -234,6 +234,7 @@ func configureLWH(*config_v1.Configuration) (yamlMap, error) {
 		writeMapEntry(cfg, "nats.container.patch", []any{}),
 		// victoria metrics
 		writeMapEntry(cfg, "victoria-metrics-k8s-stack.enabled", true),
+		writeMapEntry(cfg, "victoria-metrics-k8s-stack.victoria-metrics-operator.enabled", false),
 		writeMapEntry(cfg, "prometheus-node-exporter.enabled", true),
 		// license synchronizer job
 		writeMapEntry(cfg, "jobs.licenseSynchronizer.enabled", true),


### PR DESCRIPTION
This PR fixes possible validation webhook issues and adjust values to other vm settings