### PR TITLE
deprecated: fail every build and point at weka/gohome

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,6 +24,25 @@ jobs:
       contents: write # to create tags and github releases
 
     steps:
+      # weka/gohomecli is DEPRECATED. Releases of the Weka Home CLI are cut from
+      # https://github.com/weka/gohome. This guard fails any dispatch of this
+      # workflow from master; the release/v0.4 ref is deliberately left
+      # unguarded so an emergency hotfix can still be shipped from there.
+      - name: Repository is deprecated
+        run: |
+          echo "::error::weka/gohomecli is DEPRECATED - release from https://github.com/weka/gohome instead"
+          {
+            echo "## :warning: weka/gohomecli is deprecated"
+            echo ""
+            echo "The Weka Home CLI has moved to [weka/gohome](https://github.com/weka/gohome)."
+            echo "Cut this release from there instead:"
+            echo ""
+            echo '```'
+            echo 'git clone git@github.com:weka/gohome.git'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+          exit 1
+
       - name: Validate version format
         env:
           VERSION: ${{ github.event.inputs.version }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,25 @@
+# ============================================================================
+# weka/gohomecli is DEPRECATED. This Makefile intentionally refuses to run.
+#
+# The error function below fires during Make's read phase, so *every* target -
+# build, test, clean, all - stops here. Do not remove this guard; move to the
+# new repository instead.
+# ============================================================================
+$(info )
+$(info ============================================================================)
+$(info   weka/gohomecli is DEPRECATED - it no longer builds.)
+$(info )
+$(info   The Weka Home CLI has moved to: https://github.com/weka/gohome)
+$(info )
+$(info   You are building from a stale clone. Get the new repository:)
+$(info )
+$(info   $$ git clone git@github.com:weka/gohome.git)
+$(info )
+$(info   If you have local work here, re-apply it against weka/gohome.)
+$(info ============================================================================)
+$(info )
+$(error refusing to build a deprecated repository)
+
 BUILD_PATH=$(CURDIR)
 BIN_PATH=$(BUILD_PATH)/bin
 PKG_PATH=$(BUILD_PATH)/pkg

--- a/README.md
+++ b/README.md
@@ -1,4 +1,16 @@
-⚠️ This repository is deprecated. The CLI has been moved to weka/gohome.
+> [!CAUTION]
+> **This repository is deprecated and no longer builds.**
+>
+> The Weka Home CLI has moved to **[weka/gohome](https://github.com/weka/gohome)**.
+> Every build entry point here (`make`, `./build.sh`, `./deploy.sh`, `go build`,
+> the release workflow) fails on purpose so stale clones stop shipping from here.
+>
+> ```
+> git clone git@github.com:weka/gohome.git
+> ```
+>
+> If you have local work in this clone, re-apply it against `weka/gohome`.
+> The documentation below is kept for historical reference only.
 
 # Weka Home Command Line Utility
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,27 @@
 #!/usr/bin/env sh
 
+# ============================================================================
+# weka/gohomecli is DEPRECATED. This script intentionally refuses to run.
+# Do not remove this guard; move your work to weka/gohome instead.
+# ============================================================================
+cat >&2 <<'DEPRECATED'
+
+============================================================================
+  weka/gohomecli is DEPRECATED - it no longer builds.
+
+  The Weka Home CLI has moved to: https://github.com/weka/gohome
+
+  You are building from a stale clone. Get the new repository:
+
+    $ git clone git@github.com:weka/gohome.git
+
+  If you have local work here, re-apply it against weka/gohome.
+============================================================================
+
+DEPRECATED
+echo "::error::weka/gohomecli is deprecated - build from https://github.com/weka/gohome instead" >&2
+exit 1
+
 set -e  # Exit on any error
 
 BUILD_VERSION=$1

--- a/cmd/homecli/deprecated.go
+++ b/cmd/homecli/deprecated.go
@@ -1,0 +1,13 @@
+package main
+
+// This repository is DEPRECATED. The Weka Home CLI has moved to weka/gohome:
+//
+//	git clone git@github.com:weka/gohome.git
+//
+// The identifiers below are intentionally undefined so that any attempt to
+// build this repository fails with the new location in the compiler output.
+// Do not "fix" this file - move your work to weka/gohome instead.
+const (
+	_ = THIS_REPOSITORY_IS_DEPRECATED_AND_NO_LONGER_BUILDS
+	_ = THE_WEKA_HOME_CLI_HAS_MOVED_TO_github_com_weka_gohome
+)

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,5 +1,26 @@
 #!/usr/bin/env bash
 
+# ============================================================================
+# weka/gohomecli is DEPRECATED. This script intentionally refuses to run.
+# Do not remove this guard; move your work to weka/gohome instead.
+# ============================================================================
+cat >&2 <<'DEPRECATED'
+
+============================================================================
+  weka/gohomecli is DEPRECATED - it no longer builds.
+
+  The Weka Home CLI has moved to: https://github.com/weka/gohome
+
+  You are building from a stale clone. Get the new repository:
+
+    $ git clone git@github.com:weka/gohome.git
+
+  If you have local work here, re-apply it against weka/gohome.
+============================================================================
+
+DEPRECATED
+exit 1
+
 set -e
 
 . get_version.sh


### PR DESCRIPTION
This repository moved to https://github.com/weka/gohome, but people with existing clones never see GitHub's deprecation banner and keep building here. Make that impossible instead of advisory: every build entry point now stops with the new clone command.

- cmd/homecli/deprecated.go: undefined identifiers so go build / go vet / go test / go run / IDE compilation all fail with the redirect in the compiler output. Scoped to package main so anything importing pkg/client as a library is not collaterally broken.
- Makefile: $(error) in the read phase, so every target stops - build, test, clean, all.
- build.sh, deploy.sh: banner and exit 1 at the top. This also covers go.Dockerfile (runs build.sh) and `task deploy` (runs deploy.sh).
- .github/workflows/release.yaml: guard step fails any dispatch from master. release/v0.4 is deliberately left unguarded so an emergency hotfix can still be released from there.
- README.md: expand the notice with the clone command.